### PR TITLE
Infer inputs as a tuple, not an array

### DIFF
--- a/packages/observable-hooks/src/use-observable.ts
+++ b/packages/observable-hooks/src/use-observable.ts
@@ -39,14 +39,14 @@ export function useObservable<TOutupt>(
  * changes the Observable in `init` will emit an array of all the dependencies.
  */
 export function useObservable<TOutupt, TInputs extends Readonly<any[]>>(
-  init: (inputs$: Observable<TInputs>) => Observable<TOutupt>,
-  inputs: TInputs
+  init: (inputs$: Observable<[...TInputs]>) => Observable<TOutupt>,
+  inputs: [...TInputs]
 ): Observable<TOutupt>
 export function useObservable<TOutupt, TInputs extends Readonly<any[]>>(
   init:
     | (() => Observable<TOutupt>)
-    | ((inputs$: Observable<TInputs>) => Observable<TOutupt>),
-  inputs?: TInputs
+    | ((inputs$: Observable<[...TInputs]>) => Observable<TOutupt>),
+  inputs?: [...TInputs]
 ): Observable<TOutupt> {
   return useObservableInternal(useEffect, init, inputs)
 }


### PR DESCRIPTION
Fixes https://github.com/crimx/observable-hooks/issues/24

Are there any other places we need to fix this?

**Update**: ah, this only works in TS v4, I'll have to think of something else.