### PR TITLE
`useObservableEagerState`: throw if observable does not emit synchronously

### DIFF
--- a/packages/observable-hooks/__tests__/use-observable-eager-state.spec.ts
+++ b/packages/observable-hooks/__tests__/use-observable-eager-state.spec.ts
@@ -26,9 +26,10 @@ describe('useObservableEagerState', () => {
       spy(state)
       return state
     })
-    expect(result.current).toBe(undefined)
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(undefined)
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error.message).toBe(
+      'Observable did not synchronously emit a value.'
+    )
   })
 
   it('should update value when the Observable emits value', () => {

--- a/packages/observable-hooks/__tests__/use-observable-eager-state.spec.ts
+++ b/packages/observable-hooks/__tests__/use-observable-eager-state.spec.ts
@@ -1,7 +1,8 @@
 import { useObservableEagerState } from '../src'
 import { renderHook, act } from '@testing-library/react-hooks'
-import { of, BehaviorSubject, throwError } from 'rxjs'
+import { of, BehaviorSubject, throwError, scheduled } from 'rxjs'
 import { tap } from 'rxjs/operators'
+import { async } from 'rxjs/internal/scheduler/async'
 
 describe('useObservableEagerState', () => {
   it('should start receiving values after first rendering', () => {
@@ -15,6 +16,19 @@ describe('useObservableEagerState', () => {
     expect(result.current).toBe(3)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith(3)
+  })
+
+  it('should start receiving values after first rendering 2', () => {
+    const spy = jest.fn()
+    const outer$ = scheduled(of(1, 2, 3), async)
+    const { result } = renderHook(() => {
+      const state = useObservableEagerState(outer$)
+      spy(state)
+      return state
+    })
+    expect(result.current).toBe(undefined)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(undefined)
   })
 
   it('should update value when the Observable emits value', () => {

--- a/packages/observable-hooks/src/use-observable-eager-state.ts
+++ b/packages/observable-hooks/src/use-observable-eager-state.ts
@@ -26,11 +26,14 @@ export function useObservableEagerState<TState>(
   const errorRef = useRef<Error | null>()
   const isAsyncEmissionRef = useRef(false)
 
+  const didSyncEmit = useRef(false)
+
   const [state, setState] = useState<TState>(() => {
     let state: TState
     state$
       .subscribe({
         next: value => {
+          didSyncEmit.current = true
           state = value
         },
         error: error => {
@@ -87,7 +90,11 @@ export function useObservableEagerState<TState>(
     throw errorRef.current
   }
 
-  useDebugValue(state)
+  if (didSyncEmit.current) {
+    useDebugValue(state)
 
-  return state
+    return state
+  } else {
+    throw new Error('Observable did not synchronously emit a value.')
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/crimx/observable-hooks/issues/37