### PR TITLE
`useObservableCallback`: add separate overload for `selector`

### DIFF
--- a/packages/observable-hooks/src/use-observable-callback.ts
+++ b/packages/observable-hooks/src/use-observable-callback.ts
@@ -27,6 +27,17 @@ import { useRefFn, getEmptySubject } from './helpers'
  * @param selector A function that transforms an array of event arguments
  * into a single value.
  */
+export function useObservableCallback<TOutput, TInput = TOutput>(
+  init: (events$: Observable<TInput>) => Observable<TOutput>
+): [(args: TInput) => void, Observable<TOutput>]
+export function useObservableCallback<
+  TOutput,
+  TInput = TOutput,
+  TParams extends Readonly<any[]> = [TInput]
+>(
+  init: (events$: Observable<TInput>) => Observable<TOutput>,
+  selector: (args: TParams) => TInput
+): [(...args: TParams) => void, Observable<TOutput>]
 export function useObservableCallback<
   TOutput,
   TInput = TOutput,

--- a/packages/observable-hooks/src/use-observable-callback.ts
+++ b/packages/observable-hooks/src/use-observable-callback.ts
@@ -1,6 +1,6 @@
 import { Observable, Subject } from 'rxjs'
 import { useRef } from 'react'
-import { useRefFn, getEmptySubject, identity } from './helpers'
+import { useRefFn, getEmptySubject } from './helpers'
 
 /**
  * Returns a callback function and an events Observable.


### PR DESCRIPTION
I realised the typings for `useObservableCallback` allow for mistakes such as the following:

```ts
const [callback, value$] = useObservableCallback<
    [number, string],
    [number, string],
    [number, string]
>((value$) => {
    // Type at runtime: Observable<number> - because we have no selector function
    // Type: Observable<[number, string]> - doesn't match runtime ❌
    return value$;
});
callback(1, 'foo');
```

The `TParam` generic can be provided explicitly even when there is no `selector` function. When this happens, it's possible that the type of the runtime value will mismatch the compile time TS type.

To avoid this, this PR separates the functionality of `useObservableCallback` into two separate overloads:

- no selector param or `TParam` generic
- required selector param and `TParam` generic

I would have liked to add an `$ExpectError` test for the example above, but I don't think we currently have the infrastructure for these "type level tests"?