### PR TITLE
Render when first value changed before mount

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,8 @@
 {
-  "packages": ["packages/*", "examples/*"],
+  "packages": [
+    "packages/*",
+    "examples/*"
+  ],
   "version": "4.1.2",
   "useWorkspaces": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "packages": [".", "packages/*", "examples/*"],
+  "packages": ["packages/*", "examples/*"],
   "version": "4.1.2",
   "useWorkspaces": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,5 @@
 {
-  "packages": [
-    "packages/*",
-    "examples/*"
-  ],
+  "packages": [".", "packages/*", "examples/*"],
   "version": "4.1.2",
   "useWorkspaces": true,
   "npmClient": "yarn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "observable-hooks-mono",
-  "version": "4.1.2",
   "description": "React hooks for RxJS Observables. Simple, flexible, testable and performant.",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "observable-hooks-mono",
+  "version": "4.1.2",
   "description": "React hooks for RxJS Observables. Simple, flexible, testable and performant.",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "CRIMX<straybugs@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap && yarn build",
     "build": "lerna run --scope 'observable-*' build && lerna bootstrap",
     "test": "jest --coverage",
     "docs:dev": "vuepress dev docs",

--- a/packages/observable-hooks/__tests__/use-observable-suspense.spec.tsx
+++ b/packages/observable-hooks/__tests__/use-observable-suspense.spec.tsx
@@ -366,7 +366,7 @@ describe('useObservableSuspense', () => {
 
       /** 1. inputResource.reload */
       /** 2. clearError */
-      expect(result.renderCount).toBe(2)
+      expect(result.renderCount).toBe(3)
       expect(result.value).toBe(3)
       expect(result.getStatus()).toBe('success')
     })
@@ -408,7 +408,7 @@ describe('useObservableSuspense', () => {
 
       /** 1. inputResource.reload */
       /** 2. clearError */
-      expect(result.renderCount).toBe(2)
+      expect(result.renderCount).toBe(3)
       expect(result.value).toBe(3)
       expect(result.getStatus()).toBe('success')
     })

--- a/packages/observable-hooks/src/observable-resource.ts
+++ b/packages/observable-hooks/src/observable-resource.ts
@@ -1,4 +1,4 @@
-import { Observable, BehaviourSubject, Subscription } from 'rxjs'
+import { Observable, BehaviorSubject, Subscription } from 'rxjs'
 
 interface Handler<T = any> {
   suspender: Promise<T>
@@ -13,9 +13,9 @@ export class ObservableResource<TInput, TOutput extends TInput = TInput> {
    * Unlike Promise, Observable is a multiple push mechanism.
    * Only force update when Suspense needs to restart.
    */
-  readonly shouldUpdate$$ = new BehaviourSubject<
+  readonly shouldUpdate$$ = new BehaviorSubject<
     { current: TOutput } | undefined | void
-  >()
+  >(undefined)
 
   get isDestroyed(): boolean {
     return this._isDestroyed

--- a/packages/observable-hooks/src/observable-resource.ts
+++ b/packages/observable-hooks/src/observable-resource.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject, Subscription } from 'rxjs'
+import { Observable, BehaviourSubject, Subscription } from 'rxjs'
 
 interface Handler<T = any> {
   suspender: Promise<T>
@@ -13,7 +13,7 @@ export class ObservableResource<TInput, TOutput extends TInput = TInput> {
    * Unlike Promise, Observable is a multiple push mechanism.
    * Only force update when Suspense needs to restart.
    */
-  readonly shouldUpdate$$ = new Subject<
+  readonly shouldUpdate$$ = new BehaviourSubject<
     { current: TOutput } | undefined | void
   >()
 

--- a/packages/observable-hooks/src/observable-resource.ts
+++ b/packages/observable-hooks/src/observable-resource.ts
@@ -14,7 +14,7 @@ export class ObservableResource<TInput, TOutput extends TInput = TInput> {
    * Only force update when Suspense needs to restart.
    */
   readonly shouldUpdate$$ = new BehaviorSubject<
-    { current: TOutput } | undefined | void
+    { current: TOutput } | undefined | void | false
   >(undefined)
 
   get isDestroyed(): boolean {
@@ -125,7 +125,7 @@ export class ObservableResource<TInput, TOutput extends TInput = TInput> {
     } else if (!this.handler) {
       // start a new Suspense
       this.handler = this.getHandler()
-      this.shouldUpdate$$.next()
+      this.shouldUpdate$$.next(false)
     }
   }
 
@@ -138,7 +138,7 @@ export class ObservableResource<TInput, TOutput extends TInput = TInput> {
       // Here we resolve the suspender and let this.read throw the error.
       resolve()
     } else {
-      this.shouldUpdate$$.next()
+      this.shouldUpdate$$.next(false)
     }
   }
 

--- a/packages/observable-hooks/src/use-observable-suspense.ts
+++ b/packages/observable-hooks/src/use-observable-suspense.ts
@@ -23,7 +23,7 @@ export function useObservableSuspense<TInput, TOutput extends TInput = TInput>(
     // Schedule states to prevent tearing.
     if (valueRef) {
       setState(valueRef.current)
-    } else {
+    } else if (valueRef === false) {
       forceUpdate()
     }
   })


### PR DESCRIPTION
I ran into a race condition using this library in combination with [rxfire](https://github.com/FirebaseExtended/rxfire). The sequence of events:

1. Start mounting a component with `useObservableSuspense(resource)`
1. React starting suspense because resource is not yet loaded
1. The `resource` returns the first value from the Firestore backend
1. Component re-renders and after successfully retrieving data from the observable, it stores this data in React state `packages/observable-hooks/src/use-observable-suspense.ts:19`
1. The Firestore collection receives another piece of data
1. Component A finishes mounting
1. The `useObservableSuspense` hook will setup a subscription on the `shouldUpdate$$` observable at `packages/observable-hooks/src/internal/use-subscription-internal.ts:36` once the component is mounted.

The race condition happens with step 5. If the `resource` receives the next piece of data before mounting is completed, the `shouldUpdate$$` won't have a listener setup yet and this next piece of data is never rendered in the UI. 

One way of solving this problem is by using a [BehaviourSubject](https://rxjs.dev/guide/subject#behaviorsubject). From the docs

> One of the variants of Subjects is the BehaviorSubject, which has a notion of "the current value". It stores the latest value emitted to its consumers, and whenever a new Observer subscribes, it will immediately receive the "current value" from the BehaviorSubject.

I've also updated the `postinstall` hook to build the code so I can install this fork directly in my project adding the following line to my `package.json`:

```json
"observable-hooks": "mvgijssel/observable-hooks#workspace=observable-hooks&commit=5917bf44cccfd77839a766415b6d7d4660b5bb8d",
```