### PR TITLE
Avoid calling functions emitted by observables

### DIFF
--- a/packages/observable-hooks/src/use-observable-eager-state.ts
+++ b/packages/observable-hooks/src/use-observable-eager-state.ts
@@ -67,7 +67,7 @@ export function useObservableEagerState<TState>(
         if (isAsyncEmissionRef.current) {
           // ignore synchronous value
           // prevent initial re-rendering
-          setState(value);
+          setState(() => value);
         } else {
           secondInitialValue = value;
         }
@@ -85,7 +85,7 @@ export function useObservableEagerState<TState>(
     if (!isAsyncEmissionRef.current) {
       // fix #86 where sync emission may happen before useEffect
       if (secondInitialValue !== state) {
-        setState(secondInitialValue);
+        setState(() => secondInitialValue);
       }
     }
 


### PR DESCRIPTION
This fixes https://github.com/crimx/observable-hooks/issues/131 at least for the case of `useObservableEagerState`. Looking at the code, it seems reasonable to expect that `useObservableState` and possibly other hooks suffer from the same issue. Those fixes would be more involved, though.